### PR TITLE
Feature/add stackql ext

### DIFF
--- a/pkg/stackql/json_equal.json
+++ b/pkg/stackql/json_equal.json
@@ -1,7 +1,7 @@
 {
     "owner": "stackql",
     "name": "json_equal",
-    "version": "1.0.5",
+    "version": "v1.0.5",
     "homepage": "https://github.com/stackql/sqlite-ext-functions/blob/main/docs/json_equal.md",
     "repository": "https://github.com/stackql/sqlite-ext-functions",
     "authors": ["Jeffrey Aven"],

--- a/pkg/stackql/json_equal.json
+++ b/pkg/stackql/json_equal.json
@@ -1,0 +1,19 @@
+{
+    "owner": "stackql",
+    "name": "json_equal",
+    "version": "1.0.5",
+    "homepage": "https://github.com/stackql/sqlite-ext-functions/blob/main/docs/json_equal.md",
+    "repository": "https://github.com/stackql/sqlite-ext-functions",
+    "authors": ["Jeffrey Aven"],
+    "license": "MIT",
+    "description": "A SQLite extension for comparing JSON strings (objects or arrays) for equivalence within SQL queries.",
+    "keywords": ["JSON", "JSON comparison", "JSON equality", "json_equal"],
+    "assets": {
+        "files": {
+            "darwin-amd64": "stackql-sqlite-ext-functions-macos-universal.zip",
+            "darwin-arm64": "stackql-sqlite-ext-functions-macos-universal.zip",
+            "linux-amd64": "stackql-sqlite-ext-functions-linux-amd64.zip",
+            "windows-amd64": "stackql-sqlite-ext-functions-windows-amd64.zip"
+        }
+    }
+}

--- a/pkg/stackql/regexp.json
+++ b/pkg/stackql/regexp.json
@@ -1,0 +1,20 @@
+{
+    "owner": "stackql",
+    "name": "regexp",
+    "version": "1.0.5",
+    "homepage": "https://github.com/stackql/sqlite-ext-functions/blob/main/docs/regexp.md",
+    "repository": "https://github.com/stackql/sqlite-ext-functions",
+    "authors": ["Jeffrey Aven"],
+    "license": "MIT",
+    "description": "A SQLite extension for working with regular expressions using the tiny-regex-c library. Provides functions for pattern matching and manipulation of strings within SQL queries.",
+    "keywords": ["regexp", "regexp_like", "regexp_replace", "regexp_substr", "regular expressions", "pattern matching", "string manipulation", "tiny-regex-c"],
+    "assets": {
+        "files": {
+            "darwin-amd64": "stackql-sqlite-ext-functions-macos-universal.zip",
+            "darwin-arm64": "stackql-sqlite-ext-functions-macos-universal.zip",
+            "linux-amd64": "stackql-sqlite-ext-functions-linux-amd64.zip",
+            "windows-amd64": "stackql-sqlite-ext-functions-windows-amd64.zip"
+        }
+    }
+}
+

--- a/pkg/stackql/split_part.json
+++ b/pkg/stackql/split_part.json
@@ -1,0 +1,19 @@
+{
+    "owner": "stackql",
+    "name": "split_part",
+    "version": "1.0.5",
+    "homepage": "https://github.com/stackql/sqlite-ext-functions/blob/main/docs/split_part.md",
+    "repository": "https://github.com/stackql/sqlite-ext-functions",
+    "authors": ["Jeffrey Aven"],
+    "license": "MIT",
+    "description": "A SQLite extension for splitting strings into parts using a specified separator, PostgreSQL compatible, supporting negative indexes.",
+    "keywords": ["split_part", "string manipulation", "string splitting", "PostgreSQL compatible", "negative indexes"],
+    "assets": {
+        "files": {
+            "darwin-amd64": "stackql-sqlite-ext-functions-macos-universal.zip",
+            "darwin-arm64": "stackql-sqlite-ext-functions-macos-universal.zip",
+            "linux-amd64": "stackql-sqlite-ext-functions-linux-amd64.zip",
+            "windows-amd64": "stackql-sqlite-ext-functions-windows-amd64.zip"
+        }
+    }
+}


### PR DESCRIPTION
Added additional functions published in our package, incl:

- `regexp` functions based upon [`tiny-regex-c`](https://github.com/kokke/tiny-regex-c) - as an alternative to the `pcre2` based functions in  [`regexp`](https://github.com/nalgeon/sqlean/tree/main/src/regexp), incl [`regexp_like`](https://github.com/stackql/sqlite-ext-functions/blob/main/docs/regexp_fns.md#regexp_like), [`regexp_substr`](https://github.com/stackql/sqlite-ext-functions/blob/main/docs/regexp_fns.md#regexp_substr), [`regexp_replace`](https://github.com/stackql/sqlite-ext-functions/blob/main/docs/regexp_fns.md#regexp_replace)
- [`split_part`](https://github.com/stackql/sqlite-ext-functions/blob/main/docs/split_part.md) function compatible to [`text_split`](https://github.com/nalgeon/sqlean/blob/main/docs/text.md#text_split) - without requirement to include all `text` functions